### PR TITLE
Fix issues caused by onload event: initWidget is not defined

### DIFF
--- a/autoload.js
+++ b/autoload.js
@@ -1,6 +1,6 @@
 //注意：live2d_path参数应使用绝对路径
-const live2d_path = "https://cdn.jsdelivr.net/gh/stevenjoezhang/live2d-widget/";
-//const live2d_path = "/live2d-widget/";
+//const live2d_path = "https://cdn.jsdelivr.net/gh/stevenjoezhang/live2d-widget/";
+const live2d_path = "/js/live2d-widget/";
 
 //加载waifu.css
 $("<link>").attr({ href: live2d_path + "waifu.css", rel: "stylesheet" }).appendTo("head");

--- a/autoload.js
+++ b/autoload.js
@@ -1,6 +1,6 @@
 //注意：live2d_path参数应使用绝对路径
-//const live2d_path = "https://cdn.jsdelivr.net/gh/stevenjoezhang/live2d-widget/";
-const live2d_path = "/js/live2d-widget/";
+const live2d_path = "https://cdn.jsdelivr.net/gh/stevenjoezhang/live2d-widget/";
+//const live2d_path = "/live2d-widget/";
 
 //加载waifu.css
 $("<link>").attr({ href: live2d_path + "waifu.css", rel: "stylesheet" }).appendTo("head");

--- a/autoload.js
+++ b/autoload.js
@@ -2,39 +2,39 @@
 const live2d_path = "https://cdn.jsdelivr.net/gh/stevenjoezhang/live2d-widget/";
 //const live2d_path = "/live2d-widget/";
 
-//加载waifu.css
-$("<link>").attr({ href: live2d_path + "waifu.css", rel: "stylesheet" }).appendTo("head");
+//封装异步加载资源的方法
+function loadExternalResource(url, type) {
+	return new Promise((resolve, reject) => {
+		let tag;
 
-//加载live2d.min.js
-$.ajax({
-	url: live2d_path + "live2d.min.js",
-	dataType: "script",
-	cache: true
-});
+		if (type === "css") {
+			tag = document.createElement("link");
+			tag.rel = "stylesheet";
+			tag.href = url;
+		}
+		else if (type === "js") {
+			tag = document.createElement("script");
+			tag.src = url;
+		}
+		if (tag) {
+			tag.onload = () => resolve(url);
+			tag.onerror = () => reject(url);
+			document.head.appendChild(tag);
+		}
+	});
+}
 
-//加载waifu-tips.js
-$.ajax({
-	url: live2d_path + "waifu-tips.js",
-	dataType: "script",
-	cache: true
+//加载waifu.css live2d.min.js waifu-tips.js
+Promise.all([
+	loadExternalResource(live2d_path + "waifu.css", "css"),
+	loadExternalResource(live2d_path + "live2d.min.js", "js"),
+	loadExternalResource(live2d_path + "waifu-tips.js", "js")
+]).then(() => {
+	initWidget(live2d_path + "waifu-tips.json", "https://live2d.fghrsh.net/api");
 });
-
-//初始化看板娘，会自动加载指定目录下的waifu-tips.json
-$(window).on("load", function() {
-  if (typeof(initWidget) != "function") {
-    let clock = setInterval(function(){
-      if (typeof(initWidget) == "function") {
-        clearInterval(clock)
-        initWidget(live2d_path + "waifu-tips.json", "https://live2d.fghrsh.net/api");
-      }
-    },500)
-  } else {
-    initWidget(live2d_path + "waifu-tips.json", "https://live2d.fghrsh.net/api");
-  }
-});
-//initWidget第一个参数为waifu-tips.json的路径
-//第二个参数为api地址（无需修改）
+//initWidget第一个参数为waifu-tips.json的路径，第二个参数为api地址
 //api后端可自行搭建，参考https://github.com/fghrsh/live2d_api
+//初始化看板娘会自动加载指定目录下的waifu-tips.json
 
 console.log(`
   く__,.ヘヽ.        /  ,ー､ 〉

--- a/autoload.js
+++ b/autoload.js
@@ -21,7 +21,16 @@ $.ajax({
 
 //初始化看板娘，会自动加载指定目录下的waifu-tips.json
 $(window).on("load", function() {
-	initWidget(live2d_path + "waifu-tips.json", "https://live2d.fghrsh.net/api");
+  if (typeof(initWidget) != "function") {
+    let clock = setInterval(function(){
+      if (typeof(initWidget) == "function") {
+        clearInterval(clock)
+        initWidget(live2d_path + "waifu-tips.json", "https://live2d.fghrsh.net/api");
+      }
+    },500)
+  } else {
+    initWidget(live2d_path + "waifu-tips.json", "https://live2d.fghrsh.net/api");
+  }
 });
 //initWidget第一个参数为waifu-tips.json的路径
 //第二个参数为api地址（无需修改）


### PR DESCRIPTION
在本地测试的时候，报错 ( ReferenceError: initWidget is not defined )。
应该是 ajax 异步的锅 ( dom 加载完成这个 js 之后，触发了页面加载完成的 onload 事件。然后这个脚本里面的 ajax 才开始执行，去获取 waifu-tips.js 。此时在 onload 事件里面自然是调用不到 initWidget )

所以，我增加了一步 initWidget 是否已经加载的判断，当 initWidget 还没正常加载到时，用定时器循环这个判断，增加这段之顺利解决了在本地测试时经常性的报 ReferenceError: initWidget is not defined 错误的问题。