### PR TITLE
修复：运行时崩溃和 CI 配置错误

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -11,8 +11,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
-        with:
-          repository: hexojs/hexo-starter
       - name: Use Node.js
         uses: actions/setup-node@v6
       - name: Install Dependencies

--- a/src/cubism2/LAppModel.ts
+++ b/src/cubism2/LAppModel.ts
@@ -307,7 +307,7 @@ class LAppModel extends L2DBaseModel {
       this.physics.updateParam(this.live2DModel);
     }
 
-    if (this.lipSync == null) {
+    if (this.lipSync) {
       this.live2DModel.setParamFloat('PARAM_MOUTH_OPEN_Y', this.lipSyncValue);
     }
 
@@ -323,6 +323,7 @@ class LAppModel extends L2DBaseModel {
     for (const name in this.expressions) {
       tmp.push(name);
     }
+    if (tmp.length === 0) return;
 
     const no = Math.floor(Math.random() * tmp.length);
 
@@ -418,6 +419,7 @@ class LAppModel extends L2DBaseModel {
   }
 
   hitTest(id: string, testX: number, testY: number): boolean {
+    if (!this.modelSetting) return false;
     const len = this.modelSetting.getHitAreaNum();
     if (len == 0) {
       const hitAreasCustom = this.modelSetting.getHitAreaCustom();

--- a/src/model.ts
+++ b/src/model.ts
@@ -266,8 +266,9 @@ class ModelManager {
       this.currentModelVersion = version;
     } catch (err) {
       console.error('loadLive2D failed', err);
+    } finally {
+      this.loading = false;
     }
-    this.loading = false;
   }
 
   async loadTextureCache(modelName: string): Promise<any[]> {


### PR DESCRIPTION
## 概述

本 PR 修复了 4 个运行时崩溃/逻辑错误和 1 个 CI 配置问题。不涉及安全相关更改。

## 更改内容

### 运行时修复

#### 1. lipSync 逻辑错误导致嘴型同步失效
- **文件**: `src/cubism2/LAppModel.ts` 第 310 行
- **问题**: `if (this.lipSync == null)` 条件永远为 `false`，因为 `lipSync` 在 `L2DBaseModel` 中初始化为 `false`（布尔值），永远不会是 `null`
- **修复**: 改为 `if (this.lipSync)` 真值判断

#### 2. hitTest 空引用崩溃
- **文件**: `src/cubism2/LAppModel.ts` 第 420 行
- **问题**: `this.modelSetting` 可能为 `null`（构造函数中初始化为 `null`），调用 `getHitAreaNum()` 时抛出 `TypeError`
- **修复**: 添加 `if (!this.modelSetting) return false;` 空值守卫

#### 3. setRandomExpression 空数组崩溃
- **文件**: `src/cubism2/LAppModel.ts` 第 321 行
- **问题**: 当 `expressions` 为空对象时，`tmp` 为空数组，`tmp[0]` 为 `undefined`，传入 `setExpression(undefined)` 导致异常
- **修复**: 添加 `if (tmp.length === 0) return;` 提前返回

#### 4. loading 标志未在 finally 中重置
- **文件**: `src/model.ts` 第 270 行
- **问题**: `try` 块内的 `return` 语句（如 `cubism2Path` 或 `cubism5Path` 未设置时）会跳过 `this.loading = false`，导致后续所有模型加载被永久阻塞
- **修复**: 将 `this.loading = false` 移入 `finally` 块

### CI 修复

#### 5. tester.yml 检出错误仓库
- **文件**: `.github/workflows/tester.yml` 第 14-15 行
- **问题**: `actions/checkout@v6` 指定了 `repository: hexojs/hexo-starter`，CI 测试构建的是 hexo-starter 而非 live2d-widget
- **修复**: 移除 `repository` 配置，使用默认的当前仓库

## 修改文件

| 文件 | 更改 |
|------|------|
| `src/cubism2/LAppModel.ts` | 修复 lipSync 条件、hitTest 空值守卫、setRandomExpression 空数组检查 |
| `src/model.ts` | loading 标志移入 finally 块 |
| `.github/workflows/tester.yml` | 移除错误的仓库引用 |